### PR TITLE
Auto close

### DIFF
--- a/gnome/opensubtitles-download.py
+++ b/gnome/opensubtitles-download.py
@@ -206,7 +206,7 @@ try:
             subFileName = subFileName.replace("'", "\'")
             
             # Download and unzip selected subtitle (with progressbar)
-            process_subDownload = subprocess.call('(wget -O - ' + subURL + ' | gunzip > "' + subDirName + '/' + subFileName + '") 2>&1 | zenity --progress --auto-close --pulsate --title="Downloading subtitle, please wait..." --text="Downloading subtitle for \'' + subtitlesList['data'][0]['MovieName'] + '\' : "', shell=True)
+            process_subDownload = subprocess.call('(wget -O - ' + subURL + ' | gunzip > "' + subDirName + '/' + subFileName + '") 2>&1 | zenity --auto-close --progress --auto-close --pulsate --title="Downloading subtitle, please wait..." --text="Downloading subtitle for \'' + subtitlesList['data'][0]['MovieName'] + '\' : "', shell=True)
             
             # If an error occur, say so
             if process_subDownload != 0:


### PR DESCRIPTION
This adds a parameter to zenity command so it auto-closes after a successful download. Currently, one has to press ok, which is tiresome (and anyway, one is confirming that 'Downloading subtitle, please wait... Downloading subtitle for' - but this has already happen).
