### PR TITLE
Add a language code to the filename

### DIFF
--- a/gnome/opensubtitles-download.py
+++ b/gnome/opensubtitles-download.py
@@ -201,7 +201,7 @@ try:
             
             subDirName = os.path.dirname(moviePath)
             subURL = subtitlesList['data'][subIndex]['SubDownloadLink']
-            subFileName = os.path.basename(moviePath)[:-3] + subtitlesList['data'][subIndex]['SubFileName'][-3:]
+            subFileName = os.path.basename(moviePath)[:-4] + '_' + SubLanguageID + subtitlesList['data'][subIndex]['SubFileName'][-4:]
             subFileName = subFileName.replace('"', '\\"')
             subFileName = subFileName.replace("'", "\'")
             


### PR DESCRIPTION
Appends language code of the subtitle to the resulting filename. So instead of (typically) name_of_the_movie.srt, one gets name_of_the_movie_eng/fre/ger/etc.srt. This is useful when using this script with more then one language (now, if I download first English subtitles and then French subtitles, French subtitles rewrite English subtitles).
