### PR TITLE
Autoclose Zenity dialog if download successful

### DIFF
--- a/gnome/opensubtitles-download.py
+++ b/gnome/opensubtitles-download.py
@@ -206,7 +206,7 @@ try:
             subFileName = subFileName.replace("'", "\'")
             
             # Download and unzip selected subtitle (with progressbar)
-            process_subDownload = subprocess.call('(wget -O - ' + subURL + ' | gunzip > "' + subDirName + '/' + subFileName + '") 2>&1 | zenity --progress --pulsate --title="Downloading subtitle, please wait..." --text="Downloading subtitle for \'' + subtitlesList['data'][0]['MovieName'] + '\' : "', shell=True)
+            process_subDownload = subprocess.call('(wget -O - ' + subURL + ' | gunzip > "' + subDirName + '/' + subFileName + '") 2>&1 | zenity --progress --auto-close --pulsate --title="Downloading subtitle, please wait..." --text="Downloading subtitle for \'' + subtitlesList['data'][0]['MovieName'] + '\' : "', shell=True)
             
             # If an error occur, say so
             if process_subDownload != 0:


### PR DESCRIPTION
As asked, re-submiting without the reverts.
