### PR TITLE
Handle exit gracefully when running the script in interactive shell for debugging (i.e. in ipython)

### DIFF
--- a/gnome/opensubtitles-download.py
+++ b/gnome/opensubtitles-download.py
@@ -25,6 +25,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import struct
 import subprocess
 import mimetypes
@@ -116,7 +117,7 @@ moviePath = ''
 
 if len(argv) == 0:
     #subprocess.call(['zenity', '--error', '--text=No file selected.'])
-    exit(1)
+    sys.exit(1)
 elif argv[0] == '--file':
     moviePath = argv[1]
 else:
@@ -138,7 +139,7 @@ else:
     
     # If moviePathList is empty, abort
     if len(moviePathList) == 0:
-        exit(1)
+        sys.exit(1)
     
     # The first file will be processed immediatly
     moviePath = moviePathList[0]
@@ -154,12 +155,12 @@ try:
         # Connection to opensubtitles.org server
         session = server.LogIn('', '', 'en', 'opensubtitles-download 1.1')
         if session['status'] != '200 OK':
-            subprocess.call(['zenity', '--error', '--text=Unable to reach opensubtitles.org server : ' + session['status'] + '. Please check :\n- Your internet connection\n- www.opensubtitles.org availability'])
-            exit(1)
+            subprocess.call(['zenity', '--error', '--text=Unable to reach opensubtitles.org server: ' + session['status'] + '. Please check:\n- Your internet connection status\n- www.opensubtitles.org availability'])
+            sys.exit(1)
         token = session['token']
     except Exception:
-        subprocess.call(['zenity', '--error', '--text=Unable to reach opensubtitles.org server. Please check :\n- Your internet connection\n- www.opensubtitles.org availability'])
-        exit(1)
+        subprocess.call(['zenity', '--error', '--text=Unable to reach opensubtitles.org server. Please check:\n- Your internet connection status\n- www.opensubtitles.org availability'])
+        sys.exit(1)
     
     movieHash = hashFile(moviePath)
     movieSize = os.path.getsize(moviePath)
@@ -217,9 +218,9 @@ try:
     
     # Disconnect from opensubtitles.org server, then exit
     server.LogOut(token)
-    exit(0)
+    sys.exit(0)
 except Error:
-    # If an unknown error occur, say so and apologize
-    subprocess.call(['zenity', '--error', '--text=An unknown error occurred, sorry about that...'])
-    exit(1)
 
+    # If an unknown error occur, say so (and apologize)
+    subprocess.call(['zenity', '--error', '--text=An unknown error occurred, sorry about that... Please check:\n- Your internet connection status\n- www.opensubtitles.org availability'])
+    sys.exit(1)


### PR DESCRIPTION
ipython -i -c "%run ./opensubtitles-download.py --file movie.avi" was failing for me, this fixes that (and does not do anything bad, at least on my machine). I run the script for ipython since it is useful for further debugging - I got the namespaces and variables for free.

Github tells me I request two commits whereas I picked only one, strange:-/.
