### PR TITLE
use /usr/bin/env instead of hardcoding python path

### DIFF
--- a/OpenSubtitlesDownload.py
+++ b/OpenSubtitlesDownload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # OpenSubtitlesDownload.py / Version 3.2


### PR DESCRIPTION
perhaps more portable this way? (FreeBSD has Python in /usr/local)
