### PR TITLE
add option to search by IMDB ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Features
 - Query subtitles for multiple video files and folders at once
 - Detect valid video files (using mime types and file extensions)
 - Detect correct video titles by computing unique movie hash sums in order to download the right subtitles for the right file!
-- If the video detection fails, a backup search using filename is performed
+- If the video title detection fails, a backup search using filename is performed
+- If both the hash and filename fail to identify the correct title, you may specify
+  the IMDB ID for movies and IMDB ID and season and episode for TV shows;
+  however, when providing the IMDB ID, you may query for only one video file.
 - Download subtitles automatically if only one is available, choose the one you want otherwise
 - Download the subtitles file right next to the video file (need read/write permissions)
 - Rename downloaded subtitles to match the video file. Possibility to add a language code (ex: movie_en.srt).


### PR DESCRIPTION
I added added options to use IMDB IDs for searching.  Very quickly after starting to use this (otherwise great) tool, I found a number of files for which the hash and filename did not suffice; just two examples:

- New.Amsterdam.2018.S03E13.720p.HEVC.x265-MeGusta.mkv
- Wonder.Woman.1984.2020.720p.HMAX.WEBRip.AAC2.0.X.264-EVO.mkv

I suspect the "extra" year in the filename is blowing the search in these cases.

So, I added three options:

- --imdb {imdbid}
- --season {season-number} # only used if --imdb is given
- --episode {episode-number} # only used if --imdb is given

For movies, only --imdb is needed.  For TV shows, all three options are advisable especially if using --auto also (or you don't want to select from a long list of subtitles); but there may be cases where it makes sense to provide the full option set for a TV show.

I put in a restriction that if you specify --imdb, then you may only give one video file, and I enforce it in the code.  These new options are very valuable when:

- the hash and filename search fails (as in these examples) or is wrong
- you call this tool from a script that knows these values to make it work the first time with more certainty.

BTW, I make two more gratuitous modifications having nothing to do with this feature:

- I added some pylint warning disables because pylint is otherwise entirely useless; I find pylint useful for spotting newly added bugs more quickly
- I added an error message when providing no video files;  because the tool discards targets when they are not the right type, it is very confusing (I thought) when it does nothing. 

Thanks for your consideration; for my use case, I *need* this feature.  For others that are frustrated when the tool fails to find subtitles or the the wrong subtitles, they now have a remedy easier than fully manual repair.