### PR TITLE
Include a log when file provided in cli cannot be found

### DIFF
--- a/OpenSubtitlesDownload.py
+++ b/OpenSubtitlesDownload.py
@@ -154,6 +154,7 @@ def superPrint(priority, title, message):
 def checkFileValidity(path):
     """Check mimetype and/or file extension to detect valid video file"""
     if os.path.isfile(path) is False:
+        superPrint("info", "File not found", "The file provided was not found:\n<i>" + path + "</i>")
         return False
 
     fileMimeType, encoding = mimetypes.guess_type(path)


### PR DESCRIPTION
When using cli, if file provided is not found, the program exits giving no information to use. This PR logs when a file provided is not found.