### PR TITLE
Correct indexing in selectionCLI's for loop (0 -> 1)

### DIFF
--- a/OpenSubtitlesDownload.py
+++ b/OpenSubtitlesDownload.py
@@ -419,6 +419,7 @@ def selectionCLI(subtitlesResultList):
 
     # Print subtitles list on the terminal
     for idx, item in enumerate(subtitlesResultList['data']):
+        idx += 1
         if opt_ignore_hi and item['attributes'].get('hearing_impaired', False) == True:
             continue
         if opt_ignore_ai and item['attributes'].get('ai_translated', False) == True:


### PR DESCRIPTION
Before:
```console
>> Available subtitles:
[ 0] "Name.Of.The.Movie.1080p.x265"
[ 0] Cancel search

>> Enter your choice (0-0): 0
Cancelling search...
subIndex: -1
subName:
```

After:
```console
>> Available subtitles:
[ 1] "Name.Of.The.Movie.1080p.x265"
[ 0] Cancel search

>> Enter your choice (0-1): 1
subIndex: 0
subName: Name.Of.The.Movie.1080p.x265
```


Before:
```console
>> Available subtitles:
[ 0] "Name.Of.The.Movie.1080p.x265"
[ 1] > "HI" > "Name.Of.The.Movie.1080p.x265.Other"
[ 2] > "HI" > "Name.Of.The.Movie.1080p.x265.Another"
[ 0] Cancel search

>> Enter your choice (0-2): 1
subIndex: 0
subName: Name.Of.The.Movie.1080p.x265
```

After:
```console
>> Available subtitles:
[ 1] "Name.Of.The.Movie.1080p.x265"
[ 2] > "HI" > "Name.Of.The.Movie.1080p.x265.Other"
[ 3] > "HI" > "Name.Of.The.Movie.1080p.x265.Another"
[ 0] Cancel search

>> Enter your choice (0-3): 1
subIndex: 0
subName: Name.Of.The.Movie.1080p.x265
```

Cancel [0] works as well.